### PR TITLE
Add October context variables

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -4,6 +4,7 @@ use App;
 use Config;
 use System\Classes\PluginBase;
 use Illuminate\Foundation\AliasLoader;
+use RainLab\Ignition\Middleware\AddOctoberInformation;
 
 /**
  * Ignition Plugin Information File
@@ -37,6 +38,8 @@ class Plugin extends PluginBase
             \Illuminate\Contracts\Debug\ExceptionHandler::class,
             \RainLab\Ignition\Classes\Handler::class
         );
+
+        $this->app->get('flare.client')->registerMiddleware(AddOctoberInformation::class);
     }
 
     /**

--- a/middleware/AddOctoberInformation.php
+++ b/middleware/AddOctoberInformation.php
@@ -11,13 +11,10 @@ class AddOctoberInformation
 {
     public function handle(Report $report, $next)
     {
-        // $report->frameworkVersion(app()->version());
-
         $pluginList = '';
         $report->group('OctoberCMS information', [
             'October version' => Parameter::get('system::core.build'),
             'Plugins' => PluginVersion::all()->map(function ($plugin) use ($pluginList) {
-                // return 'foobar';
                 return $pluginList . ' ' . $plugin->code . ' (' . $plugin->version . ")";
             })
         ]);

--- a/middleware/AddOctoberInformation.php
+++ b/middleware/AddOctoberInformation.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace RainLab\Ignition\Middleware;
+
+use System\Models\Parameter;
+use Facade\FlareClient\Report;
+use System\Models\PluginVersion;
+use System\Classes\UpdateManager;
+
+class AddOctoberInformation
+{
+    public function handle(Report $report, $next)
+    {
+        // $report->frameworkVersion(app()->version());
+
+        $pluginList = '';
+        $report->group('OctoberCMS information', [
+            'October version' => Parameter::get('system::core.build'),
+            'Plugins' => PluginVersion::all()->map(function ($plugin) use ($pluginList) {
+                // return 'foobar';
+                return $pluginList . ' ' . $plugin->code . ' (' . $plugin->version . ")";
+            })
+        ]);
+
+        return $next($report);
+    }
+}


### PR DESCRIPTION
This PR will add October context variables (i.e. build version and plugins) to the rendered view under the Context tab. Ignition uses middleware to inject this information so a new middleware has been created and registered when the plugin boots. 

We may want to look at how to reorder the sections on the page as this adds the October information to the top. I'm also not sure if we can render the plugin list in a table, or if that is even desired. 